### PR TITLE
CI: switch to ghcr images; test using noble

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -29,12 +29,14 @@ jobs:
       passed: [bump-versions]
       trigger: true
     - get: stemcell
-      resource: jammy-stemcell
+      resource: container-stemcell-image
     - get: warden-cpi-registry-image
   - task: test
-    privileged: true
     file: nginx-release/ci/tasks/test.yml
     image: warden-cpi-registry-image
+    privileged: true
+    params:
+      STEMCELL_OS: ubuntu-noble
 
 - name: create-final-release
   plan:
@@ -76,21 +78,21 @@ resources:
 - name: bosh-cli-registry-image
   type: registry-image
   source:
-    repository: bosh/cli
-    username: ((dockerhub_username))
-    password: ((dockerhub_password))
+    repository: ghcr.io/cloudfoundry/bosh/cli
+    username: ((github_read_write_packages.username))
+    password: ((github_read_write_packages.password))
 
 - name: warden-cpi-registry-image
   type: registry-image
   source:
-    repository: bosh/warden-cpi
-    username: ((dockerhub_username))
-    password: ((dockerhub_password))
+    repository: ghcr.io/cloudfoundry/bosh/warden-cpi
+    username: ((github_read_write_packages.username))
+    password: ((github_read_write_packages.password))
 
-- name: jammy-stemcell
+- name: container-stemcell-image
   type: bosh-io-stemcell
   source:
-    name: bosh-warden-boshlite-ubuntu-jammy-go_agent
+    name: bosh-warden-boshlite-ubuntu-noble
 
 resource_types:
 - name: http-resource

--- a/ci/tasks/shared/bump-nginx-package.yml
+++ b/ci/tasks/shared/bump-nginx-package.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: bosh/integration
+    repository: ghcr.io/cloudfoundry/bosh/integration
 
 inputs:
 - name: input_repo

--- a/ci/tasks/test.sh
+++ b/ci/tasks/test.sh
@@ -1,16 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -eu -o pipefail
 
-set -euxo pipefail
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../.." && pwd )"
+REPO_PARENT="$( cd "${REPO_ROOT}/.." && pwd )"
+
+if [[ -n "${DEBUG:-}" ]]; then
+  set -x
+  export DEBUG="${DEBUG}"
+  export BOSH_LOG_LEVEL=debug
+  export BOSH_LOG_PATH="${BOSH_LOG_PATH:-${REPO_PARENT}/bosh-debug.log}"
+fi
 
 echo "Starting Docker and Director"
 source start-bosh
 source /tmp/local-bosh/director/env
+
+echo "Upload stemcell"
 bosh -n upload-stemcell stemcell/stemcell.tgz
 
-cd nginx-release
+echo "Deploy nginx"
+bosh -n -d test deploy \
+  --var=stemcell_os="${STEMCELL_OS}" \
+  "${REPO_ROOT}/manifests/test.yml"
 
-echo "Run tests"
-
-bosh -n -d test deploy ./manifests/test.yml
-
+echo "Run test errand"
 bosh -n -d test run-errand nginx-test

--- a/manifests/test.yml
+++ b/manifests/test.yml
@@ -8,7 +8,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-jammy
+  os: ((stemcell_os))
   version: latest
 
 update:


### PR DESCRIPTION
- [ ] re-configure the pipeline after merging

Hoping to resolve test failures:
```
[snip]
  Updating instance 'bosh/0'... Finished (00:02:06)
  Waiting for instance 'bosh/0' to be running... Failed (00:05:02)
Failed deploying (00:08:50)

Cleaning up rendered CPI jobs... Finished (00:00:00)

Deploying:
  Received non-running job state: 'starting'

Exit code 1
```

https://bosh.ci.cloudfoundry.org/teams/main/pipelines/nginx-release/jobs/test/builds/13#L69a90723:114:115